### PR TITLE
Deploy only on commits to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,5 @@ deploy:
   provider: heroku
   app: heig-pro-b04
   api_key: $HEROKU_TOKEN
+  on:
+    branch: master


### PR DESCRIPTION
Previously, there was an ambiguity as to what changes were going to be
deployed to the Heroku instance. Only the master branch will be deployed
now.