### PR TITLE
Only try to deploy builds that are on upstream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ deploy:
   api_key: $HEROKU_TOKEN
   on:
     branch: master
+    repo: heig-PRO-b04/java-backend


### PR DESCRIPTION
When using the GitHub workflow, Travis CI would automatically try to
build and deploy the project on any branch named master, including if it
is on a fork ! Because of the missing Heroku configuration, this would
make the CI fail on the forks.