### PR TITLE
Fix #10 by removing non-exposed endpoints

### DIFF
--- a/intellij-java-google-style.xml
+++ b/intellij-java-google-style.xml
@@ -2,222 +2,222 @@
 <code_scheme name="GoogleStyle">
   <option name="OTHER_INDENT_OPTIONS">
     <value>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
-      <option name="USE_TAB_CHARACTER" value="false" />
-      <option name="SMART_TABS" value="false" />
-      <option name="LABEL_INDENT_SIZE" value="0" />
-      <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-      <option name="USE_RELATIVE_INDENTS" value="false" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="TAB_SIZE" value="2"/>
+      <option name="USE_TAB_CHARACTER" value="false"/>
+      <option name="SMART_TABS" value="false"/>
+      <option name="LABEL_INDENT_SIZE" value="0"/>
+      <option name="LABEL_INDENT_ABSOLUTE" value="false"/>
+      <option name="USE_RELATIVE_INDENTS" value="false"/>
     </value>
   </option>
-  <option name="INSERT_INNER_CLASS_IMPORTS" value="true" />
-  <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
-  <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+  <option name="INSERT_INNER_CLASS_IMPORTS" value="true"/>
+  <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999"/>
+  <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999"/>
   <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
-    <value />
+    <value/>
   </option>
   <option name="IMPORT_LAYOUT_TABLE">
     <value>
-      <package name="" withSubpackages="true" static="true" />
-      <emptyLine />
-      <package name="" withSubpackages="true" static="false" />
+      <package name="" withSubpackages="true" static="true"/>
+      <emptyLine/>
+      <package name="" withSubpackages="true" static="false"/>
     </value>
   </option>
-  <option name="RIGHT_MARGIN" value="100" />
-  <option name="JD_ALIGN_PARAM_COMMENTS" value="false" />
-  <option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false" />
-  <option name="JD_P_AT_EMPTY_LINES" value="false" />
-  <option name="JD_KEEP_EMPTY_PARAMETER" value="false" />
-  <option name="JD_KEEP_EMPTY_EXCEPTION" value="false" />
-  <option name="JD_KEEP_EMPTY_RETURN" value="false" />
-  <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
-  <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
-  <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-  <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="0" />
-  <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
-  <option name="ALIGN_MULTILINE_FOR" value="false" />
-  <option name="CALL_PARAMETERS_WRAP" value="1" />
-  <option name="METHOD_PARAMETERS_WRAP" value="1" />
-  <option name="EXTENDS_LIST_WRAP" value="1" />
-  <option name="THROWS_KEYWORD_WRAP" value="1" />
-  <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
-  <option name="BINARY_OPERATION_WRAP" value="1" />
-  <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
-  <option name="TERNARY_OPERATION_WRAP" value="1" />
-  <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
-  <option name="FOR_STATEMENT_WRAP" value="1" />
-  <option name="ARRAY_INITIALIZER_WRAP" value="1" />
-  <option name="WRAP_COMMENTS" value="true" />
-  <option name="IF_BRACE_FORCE" value="3" />
-  <option name="DOWHILE_BRACE_FORCE" value="3" />
-  <option name="WHILE_BRACE_FORCE" value="3" />
-  <option name="FOR_BRACE_FORCE" value="3" />
-  <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
+  <option name="RIGHT_MARGIN" value="100"/>
+  <option name="JD_ALIGN_PARAM_COMMENTS" value="false"/>
+  <option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false"/>
+  <option name="JD_P_AT_EMPTY_LINES" value="false"/>
+  <option name="JD_KEEP_EMPTY_PARAMETER" value="false"/>
+  <option name="JD_KEEP_EMPTY_EXCEPTION" value="false"/>
+  <option name="JD_KEEP_EMPTY_RETURN" value="false"/>
+  <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false"/>
+  <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0"/>
+  <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+  <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="0"/>
+  <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+  <option name="ALIGN_MULTILINE_FOR" value="false"/>
+  <option name="CALL_PARAMETERS_WRAP" value="1"/>
+  <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+  <option name="EXTENDS_LIST_WRAP" value="1"/>
+  <option name="THROWS_KEYWORD_WRAP" value="1"/>
+  <option name="METHOD_CALL_CHAIN_WRAP" value="1"/>
+  <option name="BINARY_OPERATION_WRAP" value="1"/>
+  <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
+  <option name="TERNARY_OPERATION_WRAP" value="1"/>
+  <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
+  <option name="FOR_STATEMENT_WRAP" value="1"/>
+  <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
+  <option name="WRAP_COMMENTS" value="true"/>
+  <option name="IF_BRACE_FORCE" value="3"/>
+  <option name="DOWHILE_BRACE_FORCE" value="3"/>
+  <option name="WHILE_BRACE_FORCE" value="3"/>
+  <option name="FOR_BRACE_FORCE" value="3"/>
+  <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true"/>
   <AndroidXmlCodeStyleSettings>
-    <option name="USE_CUSTOM_SETTINGS" value="true" />
+    <option name="USE_CUSTOM_SETTINGS" value="true"/>
     <option name="LAYOUT_SETTINGS">
       <value>
-        <option name="INSERT_BLANK_LINE_BEFORE_TAG" value="false" />
+        <option name="INSERT_BLANK_LINE_BEFORE_TAG" value="false"/>
       </value>
     </option>
   </AndroidXmlCodeStyleSettings>
   <JSCodeStyleSettings>
-    <option name="INDENT_CHAINED_CALLS" value="false" />
+    <option name="INDENT_CHAINED_CALLS" value="false"/>
   </JSCodeStyleSettings>
   <Python>
-    <option name="USE_CONTINUATION_INDENT_FOR_ARGUMENTS" value="true" />
+    <option name="USE_CONTINUATION_INDENT_FOR_ARGUMENTS" value="true"/>
   </Python>
   <TypeScriptCodeStyleSettings>
-    <option name="INDENT_CHAINED_CALLS" value="false" />
+    <option name="INDENT_CHAINED_CALLS" value="false"/>
   </TypeScriptCodeStyleSettings>
   <XML>
-    <option name="XML_ALIGN_ATTRIBUTES" value="false" />
-    <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
+    <option name="XML_ALIGN_ATTRIBUTES" value="false"/>
+    <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true"/>
   </XML>
   <codeStyleSettings language="CSS">
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="ECMA Script Level 4">
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-    <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
-    <option name="ALIGN_MULTILINE_FOR" value="false" />
-    <option name="CALL_PARAMETERS_WRAP" value="1" />
-    <option name="METHOD_PARAMETERS_WRAP" value="1" />
-    <option name="EXTENDS_LIST_WRAP" value="1" />
-    <option name="BINARY_OPERATION_WRAP" value="1" />
-    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
-    <option name="TERNARY_OPERATION_WRAP" value="1" />
-    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
-    <option name="FOR_STATEMENT_WRAP" value="1" />
-    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
-    <option name="IF_BRACE_FORCE" value="3" />
-    <option name="DOWHILE_BRACE_FORCE" value="3" />
-    <option name="WHILE_BRACE_FORCE" value="3" />
-    <option name="FOR_BRACE_FORCE" value="3" />
-    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+    <option name="ALIGN_MULTILINE_FOR" value="false"/>
+    <option name="CALL_PARAMETERS_WRAP" value="1"/>
+    <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+    <option name="EXTENDS_LIST_WRAP" value="1"/>
+    <option name="BINARY_OPERATION_WRAP" value="1"/>
+    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
+    <option name="TERNARY_OPERATION_WRAP" value="1"/>
+    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
+    <option name="FOR_STATEMENT_WRAP" value="1"/>
+    <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
+    <option name="IF_BRACE_FORCE" value="3"/>
+    <option name="DOWHILE_BRACE_FORCE" value="3"/>
+    <option name="WHILE_BRACE_FORCE" value="3"/>
+    <option name="FOR_BRACE_FORCE" value="3"/>
+    <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
   </codeStyleSettings>
   <codeStyleSettings language="HTML">
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="JAVA">
-    <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-    <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
-    <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
-    <option name="ALIGN_MULTILINE_RESOURCES" value="false" />
-    <option name="ALIGN_MULTILINE_FOR" value="false" />
-    <option name="CALL_PARAMETERS_WRAP" value="1" />
-    <option name="METHOD_PARAMETERS_WRAP" value="1" />
-    <option name="EXTENDS_LIST_WRAP" value="1" />
-    <option name="THROWS_KEYWORD_WRAP" value="1" />
-    <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
-    <option name="BINARY_OPERATION_WRAP" value="1" />
-    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
-    <option name="TERNARY_OPERATION_WRAP" value="1" />
-    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
-    <option name="FOR_STATEMENT_WRAP" value="1" />
-    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
-    <option name="WRAP_COMMENTS" value="true" />
-    <option name="IF_BRACE_FORCE" value="3" />
-    <option name="DOWHILE_BRACE_FORCE" value="3" />
-    <option name="WHILE_BRACE_FORCE" value="3" />
-    <option name="FOR_BRACE_FORCE" value="3" />
-    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false"/>
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+    <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1"/>
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+    <option name="ALIGN_MULTILINE_RESOURCES" value="false"/>
+    <option name="ALIGN_MULTILINE_FOR" value="false"/>
+    <option name="CALL_PARAMETERS_WRAP" value="1"/>
+    <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+    <option name="EXTENDS_LIST_WRAP" value="1"/>
+    <option name="THROWS_KEYWORD_WRAP" value="1"/>
+    <option name="METHOD_CALL_CHAIN_WRAP" value="1"/>
+    <option name="BINARY_OPERATION_WRAP" value="1"/>
+    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
+    <option name="TERNARY_OPERATION_WRAP" value="1"/>
+    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
+    <option name="FOR_STATEMENT_WRAP" value="1"/>
+    <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
+    <option name="WRAP_COMMENTS" value="true"/>
+    <option name="IF_BRACE_FORCE" value="3"/>
+    <option name="DOWHILE_BRACE_FORCE" value="3"/>
+    <option name="WHILE_BRACE_FORCE" value="3"/>
+    <option name="FOR_BRACE_FORCE" value="3"/>
+    <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="JSON">
     <indentOptions>
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="JavaScript">
-    <option name="RIGHT_MARGIN" value="80" />
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-    <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
-    <option name="ALIGN_MULTILINE_FOR" value="false" />
-    <option name="CALL_PARAMETERS_WRAP" value="1" />
-    <option name="METHOD_PARAMETERS_WRAP" value="1" />
-    <option name="BINARY_OPERATION_WRAP" value="1" />
-    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
-    <option name="TERNARY_OPERATION_WRAP" value="1" />
-    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
-    <option name="FOR_STATEMENT_WRAP" value="1" />
-    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
-    <option name="IF_BRACE_FORCE" value="3" />
-    <option name="DOWHILE_BRACE_FORCE" value="3" />
-    <option name="WHILE_BRACE_FORCE" value="3" />
-    <option name="FOR_BRACE_FORCE" value="3" />
-    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    <option name="RIGHT_MARGIN" value="80"/>
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+    <option name="ALIGN_MULTILINE_FOR" value="false"/>
+    <option name="CALL_PARAMETERS_WRAP" value="1"/>
+    <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+    <option name="BINARY_OPERATION_WRAP" value="1"/>
+    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
+    <option name="TERNARY_OPERATION_WRAP" value="1"/>
+    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
+    <option name="FOR_STATEMENT_WRAP" value="1"/>
+    <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
+    <option name="IF_BRACE_FORCE" value="3"/>
+    <option name="DOWHILE_BRACE_FORCE" value="3"/>
+    <option name="WHILE_BRACE_FORCE" value="3"/>
+    <option name="FOR_BRACE_FORCE" value="3"/>
+    <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="PROTO">
-    <option name="RIGHT_MARGIN" value="80" />
+    <option name="RIGHT_MARGIN" value="80"/>
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="2" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="2"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="protobuf">
-    <option name="RIGHT_MARGIN" value="80" />
+    <option name="RIGHT_MARGIN" value="80"/>
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="2" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="2"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="Python">
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-    <option name="RIGHT_MARGIN" value="80" />
-    <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
-    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+    <option name="RIGHT_MARGIN" value="80"/>
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+    <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="SASS">
     <indentOptions>
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="SCSS">
     <indentOptions>
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="TypeScript">
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="XML">
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="2" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="2"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
     <arrangement>
       <rules>
@@ -226,7 +226,7 @@
             <match>
               <AND>
                 <NAME>xmlns:android</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>^$</XML_NAMESPACE>
               </AND>
             </match>
@@ -237,7 +237,7 @@
             <match>
               <AND>
                 <NAME>xmlns:.*</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>^$</XML_NAMESPACE>
               </AND>
             </match>
@@ -249,7 +249,7 @@
             <match>
               <AND>
                 <NAME>.*:id</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -260,7 +260,7 @@
             <match>
               <AND>
                 <NAME>style</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>^$</XML_NAMESPACE>
               </AND>
             </match>
@@ -271,7 +271,7 @@
             <match>
               <AND>
                 <NAME>.*</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>^$</XML_NAMESPACE>
               </AND>
             </match>
@@ -283,7 +283,7 @@
             <match>
               <AND>
                 <NAME>.*:.*Style</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -295,7 +295,7 @@
             <match>
               <AND>
                 <NAME>.*:layout_width</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -306,7 +306,7 @@
             <match>
               <AND>
                 <NAME>.*:layout_height</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -317,7 +317,7 @@
             <match>
               <AND>
                 <NAME>.*:layout_weight</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -328,7 +328,7 @@
             <match>
               <AND>
                 <NAME>.*:layout_margin</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -339,7 +339,7 @@
             <match>
               <AND>
                 <NAME>.*:layout_marginTop</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -350,7 +350,7 @@
             <match>
               <AND>
                 <NAME>.*:layout_marginBottom</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -361,7 +361,7 @@
             <match>
               <AND>
                 <NAME>.*:layout_marginStart</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -372,7 +372,7 @@
             <match>
               <AND>
                 <NAME>.*:layout_marginEnd</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -383,7 +383,7 @@
             <match>
               <AND>
                 <NAME>.*:layout_marginLeft</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -394,7 +394,7 @@
             <match>
               <AND>
                 <NAME>.*:layout_marginRight</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -405,7 +405,7 @@
             <match>
               <AND>
                 <NAME>.*:layout_.*</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -417,7 +417,7 @@
             <match>
               <AND>
                 <NAME>.*:padding</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -428,7 +428,7 @@
             <match>
               <AND>
                 <NAME>.*:paddingTop</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -439,7 +439,7 @@
             <match>
               <AND>
                 <NAME>.*:paddingBottom</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -450,7 +450,7 @@
             <match>
               <AND>
                 <NAME>.*:paddingStart</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -461,7 +461,7 @@
             <match>
               <AND>
                 <NAME>.*:paddingEnd</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -472,7 +472,7 @@
             <match>
               <AND>
                 <NAME>.*:paddingLeft</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -483,7 +483,7 @@
             <match>
               <AND>
                 <NAME>.*:paddingRight</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -537,62 +537,62 @@
     </arrangement>
   </codeStyleSettings>
   <Objective-C>
-    <option name="INDENT_NAMESPACE_MEMBERS" value="0" />
-    <option name="INDENT_C_STRUCT_MEMBERS" value="2" />
-    <option name="INDENT_CLASS_MEMBERS" value="2" />
-    <option name="INDENT_VISIBILITY_KEYWORDS" value="1" />
-    <option name="INDENT_INSIDE_CODE_BLOCK" value="2" />
-    <option name="KEEP_STRUCTURES_IN_ONE_LINE" value="true" />
-    <option name="FUNCTION_PARAMETERS_WRAP" value="5" />
-    <option name="FUNCTION_CALL_ARGUMENTS_WRAP" value="5" />
-    <option name="TEMPLATE_CALL_ARGUMENTS_WRAP" value="5" />
-    <option name="TEMPLATE_CALL_ARGUMENTS_ALIGN_MULTILINE" value="true" />
-    <option name="ALIGN_INIT_LIST_IN_COLUMNS" value="false" />
-    <option name="SPACE_BEFORE_SUPERCLASS_COLON" value="false" />
+    <option name="INDENT_NAMESPACE_MEMBERS" value="0"/>
+    <option name="INDENT_C_STRUCT_MEMBERS" value="2"/>
+    <option name="INDENT_CLASS_MEMBERS" value="2"/>
+    <option name="INDENT_VISIBILITY_KEYWORDS" value="1"/>
+    <option name="INDENT_INSIDE_CODE_BLOCK" value="2"/>
+    <option name="KEEP_STRUCTURES_IN_ONE_LINE" value="true"/>
+    <option name="FUNCTION_PARAMETERS_WRAP" value="5"/>
+    <option name="FUNCTION_CALL_ARGUMENTS_WRAP" value="5"/>
+    <option name="TEMPLATE_CALL_ARGUMENTS_WRAP" value="5"/>
+    <option name="TEMPLATE_CALL_ARGUMENTS_ALIGN_MULTILINE" value="true"/>
+    <option name="ALIGN_INIT_LIST_IN_COLUMNS" value="false"/>
+    <option name="SPACE_BEFORE_SUPERCLASS_COLON" value="false"/>
   </Objective-C>
   <Objective-C-extensions>
-    <option name="GENERATE_INSTANCE_VARIABLES_FOR_PROPERTIES" value="ASK" />
-    <option name="RELEASE_STYLE" value="IVAR" />
-    <option name="TYPE_QUALIFIERS_PLACEMENT" value="BEFORE" />
+    <option name="GENERATE_INSTANCE_VARIABLES_FOR_PROPERTIES" value="ASK"/>
+    <option name="RELEASE_STYLE" value="IVAR"/>
+    <option name="TYPE_QUALIFIERS_PLACEMENT" value="BEFORE"/>
     <file>
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Import" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Macro" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Typedef" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Enum" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Constant" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Global" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Struct" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="FunctionPredecl" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Function" />
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Import"/>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Macro"/>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Typedef"/>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Enum"/>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Constant"/>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Global"/>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Struct"/>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="FunctionPredecl"/>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Function"/>
     </file>
     <class>
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Property" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Synthesize" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InitMethod" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="StaticMethod" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InstanceMethod" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="DeallocMethod" />
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Property"/>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Synthesize"/>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InitMethod"/>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="StaticMethod"/>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InstanceMethod"/>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="DeallocMethod"/>
     </class>
     <extensions>
-      <pair source="cc" header="h" />
-      <pair source="c" header="h" />
+      <pair source="cc" header="h"/>
+      <pair source="c" header="h"/>
     </extensions>
   </Objective-C-extensions>
   <codeStyleSettings language="ObjectiveC">
-    <option name="RIGHT_MARGIN" value="80" />
-    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
-    <option name="BLANK_LINES_BEFORE_IMPORTS" value="0" />
-    <option name="BLANK_LINES_AFTER_IMPORTS" value="0" />
-    <option name="BLANK_LINES_AROUND_CLASS" value="0" />
-    <option name="BLANK_LINES_AROUND_METHOD" value="0" />
-    <option name="BLANK_LINES_AROUND_METHOD_IN_INTERFACE" value="0" />
-    <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="false" />
-    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
-    <option name="FOR_STATEMENT_WRAP" value="1" />
-    <option name="ASSIGNMENT_WRAP" value="1" />
+    <option name="RIGHT_MARGIN" value="80"/>
+    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1"/>
+    <option name="BLANK_LINES_BEFORE_IMPORTS" value="0"/>
+    <option name="BLANK_LINES_AFTER_IMPORTS" value="0"/>
+    <option name="BLANK_LINES_AROUND_CLASS" value="0"/>
+    <option name="BLANK_LINES_AROUND_METHOD" value="0"/>
+    <option name="BLANK_LINES_AROUND_METHOD_IN_INTERFACE" value="0"/>
+    <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="false"/>
+    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
+    <option name="FOR_STATEMENT_WRAP" value="1"/>
+    <option name="ASSIGNMENT_WRAP" value="1"/>
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
     </indentOptions>
   </codeStyleSettings>
 </code_scheme>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
@@ -28,20 +28,20 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-	</dependency>
+    </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
     </dependency>
-	<dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-rest</artifactId>
     </dependency>
-	<dependency>
-		<groupId>com.sipios</groupId>
-		<artifactId>spring-search</artifactId>
-		<version>0.2.0</version>
-	</dependency>
+    <dependency>
+      <groupId>com.sipios</groupId>
+      <artifactId>spring-search</artifactId>
+      <version>0.2.0</version>
+    </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
@@ -63,7 +63,7 @@
       <version>1.18.2</version>
       <scope>provided</scope>
     </dependency>
-	<dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <version>5.4.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,15 +35,6 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-data-rest</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.sipios</groupId>
-      <artifactId>spring-search</artifactId>
-      <version>0.2.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
       <exclusions>
@@ -75,10 +66,6 @@
       <version>5.4.0</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-    </dependency>
   </dependencies>
 
   <build>
@@ -103,6 +90,4 @@
       </plugin>
     </plugins>
   </build>
-
-
 </project>

--- a/src/main/java/ch/heigvd/pro/b04/polls/PollRepository.java
+++ b/src/main/java/ch/heigvd/pro/b04/polls/PollRepository.java
@@ -2,9 +2,7 @@ package ch.heigvd.pro.b04.polls;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
-@RepositoryRestResource
 public interface PollRepository extends JpaRepository<Poll, PollIdentifier>,
     JpaSpecificationExecutor<Poll> {
 


### PR DESCRIPTION
Some dependencies that were added are not actually needed, and were automagically adding some HAL-formatted discovery information on endpoints that were not exposed. This PR will then fix #10).

The PR also makes sure the `pom.xml` file is properly formatted.