### PR TITLE
Enable pretty printing for Jackson

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,3 +11,6 @@ spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 # We're also interested in knowing how the database reacts.
 spring.jpa.hibernate.ddl-auto=create
 spring.jpa.show-sql=true
+
+# We want to see some nice Json output.
+spring.jackson.serialization.indent_output=true


### PR DESCRIPTION
We're interested in having nice indentation in the API, to make
prototyping and exploration of the endpoints easier during client
development.