### PR TITLE
Implement a default 404 not found message

### DIFF
--- a/src/main/java/ch/heigvd/pro/b04/endpoints/ErrorController.java
+++ b/src/main/java/ch/heigvd/pro/b04/endpoints/ErrorController.java
@@ -11,6 +11,10 @@ public class ErrorController implements org.springframework.boot.web.servlet.err
 
   private static final String ERROR_PATH = "/error";
 
+  /**
+   * Returns a {@link ResponseEntity} whenever an error occurs because a resource could not be found
+   * on the server. The associated HTTP code is 404.
+   */
   @RequestMapping("/error")
   public ResponseEntity<ErrorResponse> notFound() {
     return new ResponseEntity<>(

--- a/src/main/java/ch/heigvd/pro/b04/endpoints/ErrorController.java
+++ b/src/main/java/ch/heigvd/pro/b04/endpoints/ErrorController.java
@@ -1,0 +1,26 @@
+package ch.heigvd.pro.b04.endpoints;
+
+import ch.heigvd.pro.b04.endpoints.exceptions.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ErrorController implements org.springframework.boot.web.servlet.error.ErrorController {
+
+  private static final String ERROR_PATH = "/error";
+
+  @RequestMapping("/error")
+  public ResponseEntity<ErrorResponse> notFound() {
+    return new ResponseEntity<>(
+        ErrorResponse.from("This resource does not exist."),
+        HttpStatus.NOT_FOUND
+    );
+  }
+
+  @Override
+  public String getErrorPath() {
+    return ErrorController.ERROR_PATH;
+  }
+}

--- a/src/main/java/ch/heigvd/pro/b04/endpoints/LoginController.java
+++ b/src/main/java/ch/heigvd/pro/b04/endpoints/LoginController.java
@@ -1,0 +1,60 @@
+package ch.heigvd.pro.b04.endpoints;
+
+import ch.heigvd.pro.b04.login.TokenCredentials;
+import ch.heigvd.pro.b04.login.UserCredentials;
+import ch.heigvd.pro.b04.login.exceptions.UnknownUserCredentialsException;
+import ch.heigvd.pro.b04.moderators.Moderator;
+import ch.heigvd.pro.b04.moderators.ModeratorRepository;
+import java.util.Optional;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class LoginController {
+
+  private ModeratorRepository moderators;
+
+  public LoginController(ModeratorRepository moderators) {
+    this.moderators = moderators;
+  }
+
+  /**
+   * Logs a user in, provided that they give their username and their password.
+   *
+   * @param credentials The credentials object that is received.
+   * @return An authentication token for the provided account.
+   * @throws UnknownUserCredentialsException If the provided credentials are unknown to the app.
+   */
+  @RequestMapping(value = "login", method = RequestMethod.POST)
+  @ResponseBody
+  public TokenCredentials login(@RequestBody UserCredentials credentials)
+      throws UnknownUserCredentialsException {
+    // FIXME : Use proper token-based authentication, rather than returning the password of the
+    //         user.
+    Optional<Moderator> moderator = moderators.findById(credentials.getUsername());
+    Optional<TokenCredentials> response = moderator.flatMap(m -> {
+      if (m.getSecret().equals(credentials.getPassword())) {
+        return Optional.of(TokenCredentials.builder().token(m.getSecret()).build());
+      } else {
+        return Optional.empty();
+      }
+    });
+    return response.orElseThrow(UnknownUserCredentialsException::new);
+  }
+
+  /**
+   * Registers a new user, assuming we got some user credentials.
+   *
+   * @param credentials The credentials to use for registration.
+   * @return An authentication token for the provided account.
+   */
+  @RequestMapping(value = "register", method = RequestMethod.POST)
+  public TokenCredentials register(@RequestBody UserCredentials credentials) {
+    Moderator moderator = new Moderator(credentials.getUsername(), credentials.getPassword());
+    moderators.saveAndFlush(moderator);
+    return TokenCredentials.builder().token(credentials.getPassword()).build();
+  }
+}

--- a/src/main/java/ch/heigvd/pro/b04/endpoints/exceptions/ErrorResponse.java
+++ b/src/main/java/ch/heigvd/pro/b04/endpoints/exceptions/ErrorResponse.java
@@ -1,0 +1,15 @@
+package ch.heigvd.pro.b04.endpoints.exceptions;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@AllArgsConstructor
+@Data
+public class ErrorResponse {
+
+  private String message;
+
+  public static ErrorResponse from(String message) {
+    return new ErrorResponse(message);
+  }
+}

--- a/src/main/java/ch/heigvd/pro/b04/endpoints/exceptions/ErrorResponseSerializer.java
+++ b/src/main/java/ch/heigvd/pro/b04/endpoints/exceptions/ErrorResponseSerializer.java
@@ -1,0 +1,22 @@
+package ch.heigvd.pro.b04.endpoints.exceptions;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import org.springframework.boot.jackson.JsonComponent;
+
+@JsonComponent
+public class ErrorResponseSerializer extends JsonSerializer<ErrorResponse> {
+
+  @Override
+  public void serialize(
+      ErrorResponse errorResponse,
+      JsonGenerator jsonGenerator,
+      SerializerProvider serializerProvider
+  ) throws IOException {
+    jsonGenerator.writeStartObject();
+    jsonGenerator.writeStringField("message", errorResponse.getMessage());
+    jsonGenerator.writeEndObject();
+  }
+}

--- a/src/main/java/ch/heigvd/pro/b04/login/TokenCredentials.java
+++ b/src/main/java/ch/heigvd/pro/b04/login/TokenCredentials.java
@@ -1,0 +1,11 @@
+package ch.heigvd.pro.b04.login;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class TokenCredentials {
+
+  private String token;
+}

--- a/src/main/java/ch/heigvd/pro/b04/login/TokenCredentialsSerializer.java
+++ b/src/main/java/ch/heigvd/pro/b04/login/TokenCredentialsSerializer.java
@@ -1,0 +1,22 @@
+package ch.heigvd.pro.b04.login;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import org.springframework.boot.jackson.JsonComponent;
+
+@JsonComponent
+public class TokenCredentialsSerializer extends JsonSerializer<TokenCredentials> {
+
+  @Override
+  public void serialize(
+      TokenCredentials tokenCredentials,
+      JsonGenerator jsonGenerator,
+      SerializerProvider serializerProvider
+  ) throws IOException {
+    jsonGenerator.writeStartObject();
+    jsonGenerator.writeStringField("token", tokenCredentials.getToken());
+    jsonGenerator.writeEndObject();
+  }
+}

--- a/src/main/java/ch/heigvd/pro/b04/login/UserCredentials.java
+++ b/src/main/java/ch/heigvd/pro/b04/login/UserCredentials.java
@@ -1,0 +1,12 @@
+package ch.heigvd.pro.b04.login;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class UserCredentials {
+
+  private String username;
+  private String password;
+}

--- a/src/main/java/ch/heigvd/pro/b04/login/UserCredentialsDeserializer.java
+++ b/src/main/java/ch/heigvd/pro/b04/login/UserCredentialsDeserializer.java
@@ -1,0 +1,26 @@
+package ch.heigvd.pro.b04.login;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import org.springframework.boot.jackson.JsonComponent;
+
+@JsonComponent
+class UserCredentialsDeserializer extends JsonDeserializer<UserCredentials> {
+
+  @Override
+  public UserCredentials deserialize(
+      JsonParser jsonParser,
+      DeserializationContext deserializationContext
+  ) throws IOException {
+    JsonNode node = jsonParser.getCodec().readTree(jsonParser);
+    String username = node.get("username").asText();
+    String password = node.get("password").asText();
+    return UserCredentials.builder()
+        .username(username)
+        .password(password)
+        .build();
+  }
+}

--- a/src/main/java/ch/heigvd/pro/b04/login/UserCredentialsSerializer.java
+++ b/src/main/java/ch/heigvd/pro/b04/login/UserCredentialsSerializer.java
@@ -1,0 +1,24 @@
+package ch.heigvd.pro.b04.login;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import org.springframework.boot.jackson.JsonComponent;
+
+@JsonComponent
+public class UserCredentialsSerializer extends JsonSerializer<UserCredentials> {
+
+  @Override
+  public void serialize(
+      UserCredentials userCredentials,
+      JsonGenerator jsonGenerator,
+      SerializerProvider serializerProvider
+  ) throws IOException {
+    jsonGenerator.writeStartObject();
+    jsonGenerator.writeStringField("username", userCredentials.getUsername());
+    jsonGenerator.writeStringField("password", userCredentials.getPassword());
+    jsonGenerator.writeEndObject();
+  }
+}
+

--- a/src/main/java/ch/heigvd/pro/b04/login/exceptions/LoginControllerExceptionHandler.java
+++ b/src/main/java/ch/heigvd/pro/b04/login/exceptions/LoginControllerExceptionHandler.java
@@ -1,0 +1,17 @@
+package ch.heigvd.pro.b04.login.exceptions;
+
+import ch.heigvd.pro.b04.endpoints.exceptions.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+public class LoginControllerExceptionHandler extends ResponseEntityExceptionHandler {
+
+  @ExceptionHandler(UnknownUserCredentialsException.class)
+  public ResponseEntity<ErrorResponse> unknownUserCredentials() {
+    return new ResponseEntity<>(ErrorResponse.from("Invalid credentials."), HttpStatus.FORBIDDEN);
+  }
+}

--- a/src/main/java/ch/heigvd/pro/b04/login/exceptions/UnknownUserCredentialsException.java
+++ b/src/main/java/ch/heigvd/pro/b04/login/exceptions/UnknownUserCredentialsException.java
@@ -1,0 +1,5 @@
+package ch.heigvd.pro.b04.login.exceptions;
+
+public class UnknownUserCredentialsException extends RuntimeException {
+
+}

--- a/src/main/java/ch/heigvd/pro/b04/moderators/Moderator.java
+++ b/src/main/java/ch/heigvd/pro/b04/moderators/Moderator.java
@@ -36,4 +36,12 @@ public class Moderator {
   public String getIdModerator() {
     return idModerator;
   }
+
+  public String getUsername() {
+    return idModerator;
+  }
+
+  public String getSecret() {
+    return secret;
+  }
 }


### PR DESCRIPTION
Currently, we are using Spring's white label page on errors. This Pull Request builds on top of #28 to use the new `ErrorResponse` entity and display it when no resource can be found at a certain URL.

This will fix #31.