### PR TITLE
Enable Cross-Origin Requests

### DIFF
--- a/src/main/java/ch/heigvd/pro/b04/CorsConfiguration.java
+++ b/src/main/java/ch/heigvd/pro/b04/CorsConfiguration.java
@@ -1,0 +1,15 @@
+package ch.heigvd.pro.b04;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfiguration implements WebMvcConfigurer {
+
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+    // We're an open API.
+    registry.addMapping("/**");
+  }
+}


### PR DESCRIPTION
From my understanding, because we're providing an open API, we should
let various clients be able to access our resources, and not protect it
with specific CORS policy.