### PR TITLE
Make the root endpoint return the API status

### DIFF
--- a/src/main/java/ch/heigvd/pro/b04/status/Status.java
+++ b/src/main/java/ch/heigvd/pro/b04/status/Status.java
@@ -1,0 +1,10 @@
+package ch.heigvd.pro.b04.status;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@AllArgsConstructor
+@Data
+public class Status {
+  private String message;
+}

--- a/src/main/java/ch/heigvd/pro/b04/status/StatusController.java
+++ b/src/main/java/ch/heigvd/pro/b04/status/StatusController.java
@@ -1,0 +1,13 @@
+package ch.heigvd.pro.b04.status;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class StatusController {
+
+  @GetMapping("/")
+  public Status status() {
+    return new Status("Everything is fine.");
+  }
+}

--- a/src/main/java/ch/heigvd/pro/b04/status/StatusSerializer.java
+++ b/src/main/java/ch/heigvd/pro/b04/status/StatusSerializer.java
@@ -1,0 +1,22 @@
+package ch.heigvd.pro.b04.status;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import org.springframework.boot.jackson.JsonComponent;
+
+@JsonComponent
+public class StatusSerializer extends JsonSerializer<Status> {
+
+  @Override
+  public void serialize(
+      Status status,
+      JsonGenerator jsonGenerator,
+      SerializerProvider serializerProvider
+  ) throws IOException {
+    jsonGenerator.writeStartObject();
+    jsonGenerator.writeStringField("message", status.getMessage());
+    jsonGenerator.writeEndObject();
+  }
+}

--- a/src/test/java/ch/heigvd/pro/b04/status/StatusControllerTest.java
+++ b/src/test/java/ch/heigvd/pro/b04/status/StatusControllerTest.java
@@ -1,0 +1,20 @@
+package ch.heigvd.pro.b04.status;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class StatusControllerTest {
+
+  @InjectMocks
+  private StatusController controller;
+
+  @Test
+  public void testStatusRespondsNormally() {
+    assertEquals("Everything is fine.", controller.status().getMessage());
+  }
+}

--- a/wiki/APIv1.md
+++ b/wiki/APIv1.md
@@ -21,3 +21,14 @@ As a general rule, and if not specified otherwise, all errors will be sent with 
     "message"       : "Error 2: This is not normal"
 }
 ```
+
+## Status
+
+When the endpoint is running, you may hit the root endpoint. You will always get a 200 response
+code, indicating that everything is fine.
+
+```json
+{
+    "message"       : "Everything is fine."
+}
+```


### PR DESCRIPTION
Clients can check that the API is up by pinging this endpoint with deterministic behavior.