### PR TITLE
Add a test case for similar user tokens

### DIFF
--- a/src/test/java/ch/heigvd/pro/b04/auth/LoginControllerTest.java
+++ b/src/test/java/ch/heigvd/pro/b04/auth/LoginControllerTest.java
@@ -79,7 +79,7 @@ public class LoginControllerTest {
   }
 
   @Test
-  public void testLoginFindsTwoUsersWithSameTokenHash() {
+  public void testLoginFindsTwoModeratorsWithSameTokenHash() {
 
     UserCredentials loggedIn = UserCredentials.builder()
         .username("u1")


### PR DESCRIPTION
If, for some random reason, two users share a token, they should still be able to authenticate and log in properly.