### PR TITLE
Change the GitHub wiki deployment script

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -12,8 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Update Wiki
-        uses: SwiftDocOrg/github-wiki-publish-action@v1
-        with:
-          path: "wiki"
-        env:
-          GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+        run : |
+          cd wiki/
+          git init .
+          git add .
+          git commit -m "Wiki update"
+          git remote add origin https://${{GH_PERSONAL_ACCESS_TOKEN}}@github.com/${{GITHUB_REPOSITORY}}.wiki.git
+          git push -u origin master --force


### PR DESCRIPTION
Rather than using a module for this, we can instead do it ourselves and
ensure a flat history of the wiki in our repository.