### PR TITLE
Make UnknownUserCredentialsException checked

### DIFF
--- a/src/main/java/ch/heigvd/pro/b04/auth/exceptions/UnknownUserCredentialsException.java
+++ b/src/main/java/ch/heigvd/pro/b04/auth/exceptions/UnknownUserCredentialsException.java
@@ -1,5 +1,5 @@
 package ch.heigvd.pro.b04.auth.exceptions;
 
-public class UnknownUserCredentialsException extends RuntimeException {
+public class UnknownUserCredentialsException extends Exception {
 
 }

--- a/src/test/java/ch/heigvd/pro/b04/auth/LoginControllerTest.java
+++ b/src/test/java/ch/heigvd/pro/b04/auth/LoginControllerTest.java
@@ -108,7 +108,9 @@ public class LoginControllerTest {
     lenient().when(moderatorRepository.findBySecret(Utils.hash("password")))
         .thenReturn(Optional.of(second));
 
-    TokenCredentials credentials = loginController.login(loggedIn);
-    assertEquals(1, credentials.getIdModerator());
+    assertDoesNotThrow(() -> {
+      TokenCredentials credentials = loginController.login(loggedIn);
+      assertEquals(1, credentials.getIdModerator());
+    });
   }
 }

--- a/src/test/java/ch/heigvd/pro/b04/polls/PollControllerTest.java
+++ b/src/test/java/ch/heigvd/pro/b04/polls/PollControllerTest.java
@@ -1,5 +1,6 @@
 package ch.heigvd.pro.b04.polls;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
@@ -42,9 +43,10 @@ public class PollControllerTest {
     when(moderators.findBySecret("secret")).thenReturn(Optional.of(moderator));
     when(polls.findAllByModerator(moderator)).thenReturn(expected);
 
-    List<Poll> response = controller.all("secret", 1);
-
-    assertEquals(expected, response);
+    assertDoesNotThrow(() -> {
+      List<Poll> response = controller.all("secret", 1);
+      assertEquals(expected, response);
+    });
   }
 
   @Test


### PR DESCRIPTION
This way, methods throwing this exception declare it in a checked fashion, reducing the risk of accidentally "forgetting" about handling them.