### PR TITLE
Specify CORS configuration to support HTTP delete method

### DIFF
--- a/src/main/java/ch/heigvd/pro/b04/CorsConfiguration.java
+++ b/src/main/java/ch/heigvd/pro/b04/CorsConfiguration.java
@@ -10,6 +10,6 @@ public class CorsConfiguration implements WebMvcConfigurer {
   @Override
   public void addCorsMappings(CorsRegistry registry) {
     // We're an open API.
-    registry.addMapping("/**");
+    registry.addMapping("/**").allowedMethods("DELETE", "GET", "POST", "PUT");
   }
 }


### PR DESCRIPTION
For some obscure reason, the "open" CORS configuration from Spring does not work with DELETE methods of HTTP. This commit fixes it.