### PR TITLE
Implement get full session

### DIFF
--- a/src/main/java/ch/heigvd/pro/b04/moderators/Moderator.java
+++ b/src/main/java/ch/heigvd/pro/b04/moderators/Moderator.java
@@ -101,7 +101,7 @@ public class Moderator {
    * @param idPoll The id of the poll
    * @return The poll associated with idPoll if it belongs to the moderator
    * @throws PollNotExistingException is thrown if the poll doesn't belong to the moderator or
-   * doesn't exist
+   *         doesn't exist
    */
   public ServerPoll getPollWithId(ServerPollRepository serverPollRepository, Integer idPoll)
       throws PollNotExistingException {
@@ -123,7 +123,7 @@ public class Moderator {
    * @param token The given token
    * @return Returns a moderator if the token and the id match
    * @throws WrongCredentialsException is thrown when the token and id don't match or if the
-   * moderator doesn't exist.
+   *         moderator doesn't exist.
    */
   public static Moderator verifyModeratorWith(
       ModeratorRepository moderatorRepository,
@@ -131,7 +131,7 @@ public class Moderator {
       String token) throws WrongCredentialsException {
 
     Optional<Moderator> modFromId = moderatorRepository.findById(idModerator);
-    if ( modFromId.isEmpty() || ! modFromId.equals(moderatorRepository.findByToken(token))) {
+    if (modFromId.isEmpty() || ! modFromId.equals(moderatorRepository.findByToken(token))) {
       throw new WrongCredentialsException();
     }
 

--- a/src/main/java/ch/heigvd/pro/b04/moderators/Moderator.java
+++ b/src/main/java/ch/heigvd/pro/b04/moderators/Moderator.java
@@ -5,6 +5,9 @@ import ch.heigvd.pro.b04.polls.ClientPoll;
 import ch.heigvd.pro.b04.polls.ServerPoll;
 import ch.heigvd.pro.b04.polls.ServerPollIdentifier;
 import ch.heigvd.pro.b04.polls.ServerPollRepository;
+import ch.heigvd.pro.b04.polls.exceptions.IllegalPollStateException;
+import ch.heigvd.pro.b04.polls.exceptions.PollNotExistingException;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import javax.persistence.CascadeType;
@@ -90,6 +93,27 @@ public class Moderator {
             .build())
         .title(poll.getTitle())
         .build());
+  }
+
+  /** Verifies that a given moderator has access to a poll.
+   *
+   * @param serverPollRepository The serverpoll repository
+   * @param idPoll The id of the poll
+   * @return The poll associated with idPoll if it belongs to the moderator
+   * @throws PollNotExistingException is thrown if the poll doesn't belong to the moderator or
+   * doesn't exist
+   */
+  public ServerPoll getPollWithId(ServerPollRepository serverPollRepository, Integer idPoll)
+      throws PollNotExistingException {
+
+    List<ServerPoll> pollList = serverPollRepository.findByModeratorAndId(this, idPoll);
+    if (pollList.isEmpty()) {
+      throw new PollNotExistingException();
+    } else if (pollList.size() > 1) {
+      throw new IllegalPollStateException();
+    }
+
+    return pollList.get(0);
   }
 
   /** Verifies that a given idModerator and token belong to the same moderator.

--- a/src/main/java/ch/heigvd/pro/b04/moderators/Moderator.java
+++ b/src/main/java/ch/heigvd/pro/b04/moderators/Moderator.java
@@ -1,9 +1,11 @@
 package ch.heigvd.pro.b04.moderators;
 
+import ch.heigvd.pro.b04.auth.exceptions.WrongCredentialsException;
 import ch.heigvd.pro.b04.polls.ClientPoll;
 import ch.heigvd.pro.b04.polls.ServerPoll;
 import ch.heigvd.pro.b04.polls.ServerPollIdentifier;
 import ch.heigvd.pro.b04.polls.ServerPollRepository;
+import java.util.Optional;
 import java.util.Set;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
@@ -88,5 +90,27 @@ public class Moderator {
             .build())
         .title(poll.getTitle())
         .build());
+  }
+
+  /** Verifies that a given idModerator and token belong to the same moderator.
+   *
+   * @param moderatorRepository The moderator repository
+   * @param idModerator The given moderator id
+   * @param token The given token
+   * @return Returns a moderator if the token and the id match
+   * @throws WrongCredentialsException is thrown when the token and id don't match or if the
+   * moderator doesn't exist.
+   */
+  public static Moderator verifyModeratorWith(
+      ModeratorRepository moderatorRepository,
+      Integer idModerator,
+      String token) throws WrongCredentialsException {
+
+    Optional<Moderator> modFromId = moderatorRepository.findById(idModerator);
+    if ( modFromId.isEmpty() || ! modFromId.equals(moderatorRepository.findByToken(token))) {
+      throw new WrongCredentialsException();
+    }
+
+    return modFromId.get();
   }
 }

--- a/src/main/java/ch/heigvd/pro/b04/moderators/Moderator.java
+++ b/src/main/java/ch/heigvd/pro/b04/moderators/Moderator.java
@@ -5,9 +5,7 @@ import ch.heigvd.pro.b04.polls.ClientPoll;
 import ch.heigvd.pro.b04.polls.ServerPoll;
 import ch.heigvd.pro.b04.polls.ServerPollIdentifier;
 import ch.heigvd.pro.b04.polls.ServerPollRepository;
-import ch.heigvd.pro.b04.polls.exceptions.IllegalPollStateException;
 import ch.heigvd.pro.b04.polls.exceptions.PollNotExistingException;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import javax.persistence.CascadeType;
@@ -106,14 +104,12 @@ public class Moderator {
   public ServerPoll getPollWithId(ServerPollRepository serverPollRepository, Integer idPoll)
       throws PollNotExistingException {
 
-    List<ServerPoll> pollList = serverPollRepository.findByModeratorAndId(this, idPoll);
-    if (pollList.isEmpty()) {
+    Optional<ServerPoll> poll = serverPollRepository.findByModeratorAndId(this, idPoll);
+    if (poll.isEmpty()) {
       throw new PollNotExistingException();
-    } else if (pollList.size() > 1) {
-      throw new IllegalPollStateException();
     }
 
-    return pollList.get(0);
+    return poll.get();
   }
 
   /** Verifies that a given idModerator and token belong to the same moderator.

--- a/src/main/java/ch/heigvd/pro/b04/polls/ServerPollRepository.java
+++ b/src/main/java/ch/heigvd/pro/b04/polls/ServerPollRepository.java
@@ -2,6 +2,7 @@ package ch.heigvd.pro.b04.polls;
 
 import ch.heigvd.pro.b04.moderators.Moderator;
 import java.util.List;
+import java.util.Optional;
 import javax.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -14,7 +15,7 @@ public interface ServerPollRepository extends JpaRepository<ServerPoll, ServerPo
 
   @Query("SELECT p FROM ServerPoll p"
       + " WHERE p.idPoll.idxModerator = :moderator AND p.idPoll.idPoll = :pollId")
-  List<ServerPoll> findByModeratorAndId(Moderator moderator, long pollId);
+  Optional<ServerPoll> findByModeratorAndId(Moderator moderator, long pollId);
 
   @Transactional
   @Modifying

--- a/src/main/java/ch/heigvd/pro/b04/polls/exceptions/IllegalPollStateException.java
+++ b/src/main/java/ch/heigvd/pro/b04/polls/exceptions/IllegalPollStateException.java
@@ -1,0 +1,7 @@
+package ch.heigvd.pro.b04.polls.exceptions;
+
+public class IllegalPollStateException extends IllegalStateException {
+  public IllegalPollStateException() {
+    super("Impossible state occured. More than one poll with the same id");
+  }
+}

--- a/src/main/java/ch/heigvd/pro/b04/polls/exceptions/IllegalPollStateException.java
+++ b/src/main/java/ch/heigvd/pro/b04/polls/exceptions/IllegalPollStateException.java
@@ -1,7 +1,0 @@
-package ch.heigvd.pro.b04.polls.exceptions;
-
-public class IllegalPollStateException extends IllegalStateException {
-  public IllegalPollStateException() {
-    super("Impossible state occured. More than one poll with the same id");
-  }
-}

--- a/src/main/java/ch/heigvd/pro/b04/sessions/SessionController.java
+++ b/src/main/java/ch/heigvd/pro/b04/sessions/SessionController.java
@@ -123,14 +123,7 @@ public class SessionController {
       SessionStateMustBeClosedFirstException {
 
     Moderator moderator = Moderator.verifyModeratorWith(moderatorRepository, idModerator, token);
-
-    // 2. Check that the poll exists and that we have access
-    List<ServerPoll> pollList = serverPollRepository.findByModeratorAndId(moderator, idPoll);
-    if (pollList.isEmpty()) {
-      throw new PollNotExistingException();
-    }
-
-    ServerPoll poll = pollList.get(0);
+    ServerPoll poll = moderator.getPollWithId(serverPollRepository, idPoll);
 
     Optional<ServerSession> last = poll.getLatestSession(sessionRepository);
     ServerSession session;

--- a/src/main/java/ch/heigvd/pro/b04/sessions/SessionController.java
+++ b/src/main/java/ch/heigvd/pro/b04/sessions/SessionController.java
@@ -122,14 +122,10 @@ public class SessionController {
       SessionStateMustBeOpenedFirstException,
       SessionStateMustBeClosedFirstException {
 
-    // 1. Authenticate moderator
-    Optional<Moderator> modFromId = moderatorRepository.findById(idModerator);
-    if (! modFromId.equals(moderatorRepository.findByToken(token))) {
-      throw new WrongCredentialsException();
-    }
+    Moderator moderator = Moderator.verifyModeratorWith(moderatorRepository, idModerator, token);
 
     // 2. Check that the poll exists and that we have access
-    List<ServerPoll> pollList = serverPollRepository.findByModeratorAndId(modFromId.get(), idPoll);
+    List<ServerPoll> pollList = serverPollRepository.findByModeratorAndId(moderator, idPoll);
     if (pollList.isEmpty()) {
       throw new PollNotExistingException();
     }

--- a/src/main/java/ch/heigvd/pro/b04/sessions/SessionController.java
+++ b/src/main/java/ch/heigvd/pro/b04/sessions/SessionController.java
@@ -192,6 +192,7 @@ public class SessionController {
    * @throws SessionNotExistingException is thrown if the poll never had a session
    */
   @GetMapping(value = "/mod/{idModerator}/poll/{idPoll}/session")
+  @Transactional
   public ServerSession getLastActiveSession(
       @PathVariable(name = "idModerator") Integer idModerator,
       @PathVariable(name = "idPoll") Integer idPoll,

--- a/src/main/java/ch/heigvd/pro/b04/sessions/SessionController.java
+++ b/src/main/java/ch/heigvd/pro/b04/sessions/SessionController.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import javax.transaction.Transactional;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -65,7 +66,7 @@ public class SessionController {
    * @throws ResourceNotFoundException    If the session does not exist
    */
   @Transactional
-  @RequestMapping(value = "/connect", method = RequestMethod.POST)
+  @PostMapping(value = "/connect")
   public UserToken byCode(@RequestBody SessionCode codeReceived)
       throws SessionNotAvailableException,
       ResourceNotFoundException,
@@ -188,4 +189,10 @@ public class SessionController {
 
     return sessionRepository.saveAndFlush(session);
   }
+
+  @GetMapping(value = "/mod/{idModerator}/poll/{idPoll}/session")
+  public ServerSession putSession() {
+
+  }
+
 }

--- a/src/test/java/ch/heigvd/pro/b04/sessions/SessionControllerTest.java
+++ b/src/test/java/ch/heigvd/pro/b04/sessions/SessionControllerTest.java
@@ -14,11 +14,6 @@ import ch.heigvd.pro.b04.polls.exceptions.PollNotExistingException;
 import ch.heigvd.pro.b04.sessions.exceptions.SessionCodeNotHexadecimalException;
 import ch.heigvd.pro.b04.sessions.exceptions.SessionNotAvailableException;
 import ch.heigvd.pro.b04.sessions.exceptions.SessionNotExistingException;
-import java.sql.Timestamp;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -100,7 +95,7 @@ public class SessionControllerTest {
         when(moderatorRepository.findByToken(token)).thenReturn(Optional.of(moderator));
 
         when(serverPollRepository.findByModeratorAndId(moderator, idPoll))
-            .thenReturn(new ArrayList<>());
+            .thenReturn(Optional.empty());
 
         assertThrows(PollNotExistingException.class,
             () -> sessionController.putSession(idMod, idPoll, token, clientSession));
@@ -154,7 +149,7 @@ public class SessionControllerTest {
         when(moderatorRepository.findById(idMod)).thenReturn(Optional.of(moderator));
         when(moderatorRepository.findByToken(token)).thenReturn(Optional.of(moderator));
         when(serverPollRepository.findByModeratorAndId(moderator, idPoll)).thenReturn(
-            Collections.singletonList(serverPoll)
+            Optional.of(serverPoll)
         );
 
         assertThrows(SessionNotExistingException.class,
@@ -184,58 +179,10 @@ public class SessionControllerTest {
         when(moderatorRepository.findById(idMod)).thenReturn(Optional.of(moderator));
         when(moderatorRepository.findByToken(token)).thenReturn(Optional.of(moderator));
         when(serverPollRepository.findByModeratorAndId(moderator, idPoll)).thenReturn(
-            Collections.singletonList(serverPoll)
+            Optional.of(serverPoll)
         );
         when(sessionRepository.findByModAndPoll(moderator, serverPoll)).thenReturn(
             Collections.singletonList(serverSession)
-        );
-
-        assertEquals(serverSession, sessionController.getLastActiveSession(idMod, idPoll, token));
-    }
-
-    @Test
-    public void testGetLastActiveSessionWithMultipleSessionsReturnsCorrectSession()
-        throws WrongCredentialsException, SessionNotExistingException, PollNotExistingException, ParseException {
-        int idMod = 1;
-        int idPoll = 5;
-        String token = "habababa";
-        Moderator moderator = Moderator.builder()
-            .idModerator(idMod)
-            .build();
-
-        ServerPoll serverPoll = ServerPoll.builder()
-            .idPoll(ServerPollIdentifier.builder()
-                .idPoll(idPoll)
-                .idxModerator(moderator)
-                .build())
-            .title("My poll")
-            .build();
-
-        ServerSession oldSession = ServerSession.builder()
-            .state(SessionState.CLOSED)
-            .timestampStart(
-                new Timestamp(new SimpleDateFormat("dd-MM-yyyy")
-                        .parse("01-01-1990")
-                        .getTime()
-                ))
-            .timestampEnd(
-                new Timestamp(new SimpleDateFormat("dd-MM-yyyy")
-                        .parse("02-01-1990")
-                        .getTime()
-                ))
-            .build();
-        ServerSession serverSession = ServerSession.builder()
-            .state(SessionState.OPEN)
-            .timestampStart(new Timestamp(System.currentTimeMillis()))
-            .build();
-
-        when(moderatorRepository.findById(idMod)).thenReturn(Optional.of(moderator));
-        when(moderatorRepository.findByToken(token)).thenReturn(Optional.of(moderator));
-        when(serverPollRepository.findByModeratorAndId(moderator, idPoll)).thenReturn(
-            Collections.singletonList(serverPoll)
-        );
-        when(sessionRepository.findByModAndPoll(moderator, serverPoll)).thenReturn(
-            Arrays.asList(oldSession, serverSession)
         );
 
         assertEquals(serverSession, sessionController.getLastActiveSession(idMod, idPoll, token));

--- a/src/test/java/ch/heigvd/pro/b04/sessions/SessionControllerTest.java
+++ b/src/test/java/ch/heigvd/pro/b04/sessions/SessionControllerTest.java
@@ -117,11 +117,9 @@ public class SessionControllerTest {
         int idMod = 1;
         int idPoll = 5;
         String token = "habababa";
-        Moderator moderator = new Moderator();
         ClientSession clientSession = ClientSession.builder().build();
 
         when(moderatorRepository.findById(idMod)).thenReturn(Optional.empty());
-        when(moderatorRepository.findByToken(token)).thenReturn(Optional.of(moderator));
 
         assertThrows(WrongCredentialsException.class,
             () -> sessionController.putSession(idMod, idPoll, token, clientSession));


### PR DESCRIPTION
This will fix the second point of issue #124 

Note that the server still doesn't respond with the correct json session representation:
```
{
  'idSession': {'idSession': 1},
  'timestampStart': '2020-04-19T07:07:37.952+0000',
  'timestampEnd': None,
  'code': '0xb5c4',
  'state': 'OPEN'
}
```
instead of 
```
{
  'idModerator': 1,
  'idPoll': 1,
  'idSession': 1,
  'timestampStart': '2020-04-19T07:07:37.952+0000',
  'timestampEnd': None,
  'code': '0xb5c4',
  'state': 'OPEN'
}
```